### PR TITLE
Fix issue lost braces

### DIFF
--- a/R/get_airnow_area.R
+++ b/R/get_airnow_area.R
@@ -7,7 +7,7 @@
 #' @param box Four-element numeric vector specifying a bounding box for the
 #'   region of interest. Format is (minX, minY, maxX, maxY), where X and Y are
 #'   longitude and latitude, respectively.
-#' @param parameters Parameter(s) to return data for. Choices are PM_{2.5}
+#' @param parameters Parameter(s) to return data for. Choices are PM_\{2.5\}
 #'   (`pm25`: default), `ozone`, PM_10 (`pm10`), CO (`co`), NO2 (`no2`), and
 #'   SO2 (`so2`).
 #' @param start_time Optional. The date and time (UTC) at the start of the time

--- a/man/get_airnow_area.Rd
+++ b/man/get_airnow_area.Rd
@@ -22,7 +22,7 @@ get_airnow_area(
 region of interest. Format is (minX, minY, maxX, maxY), where X and Y are
 longitude and latitude, respectively.}
 
-\item{parameters}{Parameter(s) to return data for. Choices are PM_{2.5}
+\item{parameters}{Parameter(s) to return data for. Choices are PM_\{2.5\}
 (\code{pm25}: default), \code{ozone}, PM_10 (\code{pm10}), CO (\code{co}), NO2 (\code{no2}), and
 SO2 (\code{so2}).}
 


### PR DESCRIPTION
This pull request addresses documentation issues detected by R CMD check under the “Rd files” check. Specifically, the package help files contained instances of “Lost braces”, where braces were not correctly escaped.

Such issues result in mis-formatted documentation and produce a NOTE on CRAN checks. The problems were identified via the regular CRAN checks on the r-devel-linux-x86_64-debian-gcc platform.

**Changes made**

- `get_airnow_area.R`: Escaped braces in parameter description (PM\_{2.5}) to resolve.
- Corrected unescaped braces in `.Rd` files (or regenerated .Rd files via roxygen2 if applicable).
- Ensured that macros such as `\eqn{}`, `\doi{}`, and `\code{}` are used correctly.
 

**Verified fixes with:**
- `tools::checkRd()` to confirm syntax validity.
- `tools::Rd2HTML()` to preview rendered documentation.

Confirmed that R CMD check now passes without the previous “Lost braces” NOTE.

**Background**

This task was proposed by R Core developer Kurt Hornik. It is part of an initiative to help package authors by submitting pull requests to public repositories that exhibit easily resolvable CRAN check issues, starting with “Lost braces” in documentation files.

**Next steps**

If the package uses roxygen2, you may wish to regenerate documentation to ensure future updates do not reintroduce these issues. Otherwise, the corrected .Rd files can be merged directly.